### PR TITLE
README: Rename svelterust to lambdachad

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Options:
 
 There are multiple ways to install this:
 
-1. Go to [releases](https://github.com/svelterust/raise/releases)
-2. `cargo install --git https://github.com/svelterust/raise`
-3. Add `github:svelterust/raise` as a flake to your NixOS configuration
+1. Go to [releases](https://github.com/lambdachad/raise/releases)
+2. `cargo install --git https://github.com/lambdachad/raise`
+3. Add `github:lambdachad/raise` as a flake to your NixOS configuration
 
 For NixOS, add raise to your flake inputs:
 
 ```nix
 inputs = {
-  raise.url = "github:svelterust/raise";
+  raise.url = "github:lambdachad/raise";
 };
 ```
 


### PR DESCRIPTION
This PR sets the URLs to the correct GitHub paths in the README. I think you changed username recently.